### PR TITLE
[v0.2] Refresh the BERT applied in tensorflow 2.10

### DIFF
--- a/modelzoo/bert/patch_bert.sh
+++ b/modelzoo/bert/patch_bert.sh
@@ -3,7 +3,7 @@
 get_original_model () {
     git init &&
     git config remote.origin_bert.url >&- || git remote add origin_bert https://github.com/IntelAI/models.git &&
-    git pull origin_bert r2.5
+    rm README.md && git pull origin_bert r2.5
 }
 
 apply_patch () {


### PR DESCRIPTION
This PR is updated with the newly-refreshed BERT in the tensorflow-2.10 because of some API usage change from tensorflow-2.05 to 2.10, which has tested well in the innersource jenkins test. Please help review this PR. Thx. @xuechendi 