### PR TITLE
[v0.3] Refine PyPI nightly build release version issue

### DIFF
--- a/.github/workflows/e2eaiok_nightly_pypi.yml
+++ b/.github/workflows/e2eaiok_nightly_pypi.yml
@@ -34,8 +34,9 @@ jobs:
       run: |
         pip install build wheel
         release_version=$(cat e2eAIOK/version | head -1)
-        nightly_build_date=`date '+%Y%m%d%H'`
-        nightly_version=${release_version}b${nightly_build_date}
+        next_release_version=$(echo ${release_version} | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{$NF=sprintf("%0*d", length($NF), ($NF+1)); print}')
+        nightly_build_date=`date '+%Y%m%d'`
+        nightly_version=${next_release_version}b${nightly_build_date}
         echo $nightly_version > e2eAIOK/version
         python3 setup.py bdist_wheel --python-tag py3
 

--- a/.github/workflows/e2eaiok_nightly_pypi.yml
+++ b/.github/workflows/e2eaiok_nightly_pypi.yml
@@ -35,7 +35,7 @@ jobs:
         pip install build wheel
         release_version=$(cat e2eAIOK/version | head -1)
         next_release_version=$(echo ${release_version} | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{$NF=sprintf("%0*d", length($NF), ($NF+1)); print}')
-        nightly_build_date=`date '+%Y%m%d'`
+        nightly_build_date=`date '+%Y%m%d%H'`
         nightly_version=${next_release_version}b${nightly_build_date}
         echo $nightly_version > e2eAIOK/version
         python3 setup.py bdist_wheel --python-tag py3


### PR DESCRIPTION
1. Refine e2eAIOK PyPI nightly build release version

-          automatic increment minor version number for nightly:
-          such as 0.2.4 (stable release)--> 0.2.5b20221206 (pre-release nightly)