### PR TITLE
[v1.0 fix] rename DockerfilePytorch120 to DockerfilePytorch112

### DIFF
--- a/Dockerfile-ubuntu18.04/DockerfilePytorch112
+++ b/Dockerfile-ubuntu18.04/DockerfilePytorch112
@@ -1,4 +1,4 @@
-# For v0.3 DeNas
+# For v1.0 DeNas
 FROM intel/oneapi-aikit:2022.3.0-devel-ubuntu18.04
 
 SHELL ["/bin/bash", "-c"]

--- a/Dockerfile-ubuntu18.04/README.md
+++ b/Dockerfile-ubuntu18.04/README.md
@@ -5,7 +5,7 @@ $ cd Dockerfile-ubuntu18.04
 $ docker build -t e2eaiok-tensorflow . -f DockerfileTensorflow
 $ docker build -t e2eaiok-pytorch . -f DockerfilePytorch
 $ docker build -t e2eaiok-pytorch110 . -f DockerfilePytorch110
-$ docker build -t e2eaiok-pytorch120 . -f DockerfilePytorch120
+$ docker build -t e2eaiok-pytorch112 . -f DockerfilePytorch112
 ```
 
 Notice:
@@ -15,5 +15,5 @@ $ cd Dockerfile-ubuntu18.04
 $ docker build -t e2eaiok-tensorflow . -f DockerfileTensorflow --build-arg http_proxy=http://proxy-ip:proxy-port --build-arg https_proxy=http://proxy-ip:proxy-port
 $ docker build -t e2eaiok-pytorch . -f DockerfilePytorch --build-arg http_proxy=http://proxy-ip:proxy-port --build-arg https_proxy=http://proxy-ip:proxy-port
 $ docker build -t e2eaiok-pytorch110 . -f DockerfilePytorch110 --build-arg http_proxy=http://proxy-ip:proxy-port --build-arg https_proxy=http://proxy-ip:proxy-port
-$ docker build -t e2eaiok-pytorch120 . -f DockerfilePytorch120 --build-arg http_proxy=http://proxy-ip:proxy-port --build-arg https_proxy=http://proxy-ip:proxy-port
+$ docker build -t e2eaiok-pytorch112 . -f DockerfilePytorch112 --build-arg http_proxy=http://proxy-ip:proxy-port --build-arg https_proxy=http://proxy-ip:proxy-port
 ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For more information, you may [read the docs](https://github.com/intel/e2eAIOK).
 ```
 git clone https://github.com/intel/e2eAIOK.git
 git submodule update --init --recursive
-cd e2eAIOK; python scripts/start_e2eaiok_docker.py --backend [tensorflow, pytorch, pytorch110, pytorch120] --dataset_path ../ --workers host1, host2, host3, host4 --proxy "http://addr:ip"
+cd e2eAIOK; python scripts/start_e2eaiok_docker.py --backend [tensorflow, pytorch, pytorch110, pytorch112] --dataset_path ../ --workers host1, host2, host3, host4 --proxy "http://addr:ip"
 ```
 
 ## Demos 

--- a/demo/denas/asr/DENAS_ASR_DEMO.ipynb
+++ b/demo/denas/asr/DENAS_ASR_DEMO.ipynb
@@ -57,7 +57,7 @@
     "# Setup ENV\n",
     "git clone https://github.com/intel/e2eAIOK.git\n",
     "cd e2eAIOK\n",
-    "python3 scripts/start_e2eaiok_docker.py -b pytorch120 -w ${host0} ${host1} ${host2} ${host3} --proxy \"\"\n",
+    "python3 scripts/start_e2eaiok_docker.py -b pytorch112 -w ${host0} ${host1} ${host2} ${host3} --proxy \"\"\n",
     "```\n",
     "\n",
     "## Enter Docker\n",

--- a/demo/denas/bert/DENAS_BERT_DEMO.ipynb
+++ b/demo/denas/bert/DENAS_BERT_DEMO.ipynb
@@ -64,7 +64,7 @@
     "git submodule update --init –recursive\n",
     "\n",
     "# build the docker\n",
-    "python3 scripts/start_e2eaiok_docker.py -b pytorch120 -w ${host0} ${host1} ${host2} ${host3} --proxy \"\"\n",
+    "python3 scripts/start_e2eaiok_docker.py -b pytorch112 -w ${host0} ${host1} ${host2} ${host3} --proxy \"\"\n",
     "```\n"
    ]
   },

--- a/demo/denas/computer_vision/DENAS_COMPUTER_VISION_DEMO.ipynb
+++ b/demo/denas/computer_vision/DENAS_COMPUTER_VISION_DEMO.ipynb
@@ -78,7 +78,7 @@
     "git clone https://github.com/intel/e2eAIOK.git\n",
     "cd e2eAIOK\n",
     "git submodule update --init –recursive\n",
-    "python3 scripts/start_e2eaiok_docker.py -b pytorch120 -w ${host0} ${host1} ${host2} ${host3} --proxy \"\"\n",
+    "python3 scripts/start_e2eaiok_docker.py -b pytorch112 -w ${host0} ${host1} ${host2} ${host3} --proxy \"\"\n",
     "```\n",
     "\n",
     "## Enter Docker\n",

--- a/e2eAIOK/DeNas/README.md
+++ b/e2eAIOK/DeNas/README.md
@@ -29,7 +29,7 @@ The train-free score uses an innovative, zero-cost “proxy” to predict model 
 git clone https://github.com/intel/e2eAIOK.git
 cd e2eAIOK
 git submodule update --init --recursive
-python3 scripts/start_e2eaiok_docker.py -b pytorch120 -w ${host0} ${host1} ${host2} ${host3} --proxy ""
+python3 scripts/start_e2eaiok_docker.py -b pytorch112 -w ${host0} ${host1} ${host2} ${host3} --proxy ""
 ```
 
  Enter Docker

--- a/scripts/start_e2eaiok_docker.py
+++ b/scripts/start_e2eaiok_docker.py
@@ -12,7 +12,7 @@ current_folder = os.getcwd()
 def parse_args(args):
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-    parser.add_argument('-b', '--backend',choices=['tensorflow', 'pytorch', 'pytorch110', 'pytorch120'],default='pytorch110')
+    parser.add_argument('-b', '--backend',choices=['tensorflow', 'pytorch', 'pytorch110', 'pytorch112'],default='pytorch110')
     parser.add_argument('-dp', '--dataset_path',type=str,default="../e2eaiok_dataset",help='large capacity folder for dataset storing')
     parser.add_argument('--proxy', type=str, default=None, help='proxy for pip and apt install')
     parser.add_argument('--log_path',type=str,default="./e2eaiok_docker_building.log",help='large capacity folder for dataset storing')
@@ -314,10 +314,10 @@ def main(input_args):
         docker_nickname = "e2eaiok-pytorch"
         port = 12346
     # pytorch1.12 env
-    if input_args.backend == 'pytorch120':
-        docker_name = "e2eaiok-pytorch120"
-        docker_file = "DockerfilePytorch120"
-        docker_nickname = "e2eaiok-pytorch120"
+    if input_args.backend == 'pytorch112':
+        docker_name = "e2eaiok-pytorch112"
+        docker_file = "DockerfilePytorch112"
+        docker_nickname = "e2eaiok-pytorch112"
         port = 12347
 
     # 0. prepare_env

--- a/tests/cicd/DeNasJenkinsfile
+++ b/tests/cicd/DeNasJenkinsfile
@@ -14,7 +14,7 @@ pipeline {
                             node(label) {
                                 cleanWs()
                                 checkout scm
-                                sh 'cd Dockerfile-ubuntu18.04 && docker build -t e2eaiok-pytorch120 . -f DockerfilePytorch120 && cd .. && yes | docker container prune && yes | docker image prune'
+                                sh 'cd Dockerfile-ubuntu18.04 && docker build -t e2eaiok-pytorch112 . -f DockerfilePytorch112 && cd .. && yes | docker container prune && yes | docker image prune'
                             }
                         }
                     }
@@ -27,7 +27,7 @@ pipeline {
                 label 'sr612'
             }
             steps {
-                sh 'docker run --rm --name test-denas-cnn --privileged --network host --device=/dev/dri -v /mnt/DP_disk1/dataset:/home/vmagent/app/dataset -v `pwd`:/home/vmagent/app/e2eaiok -w /home/vmagent/app/ e2eaiok-pytorch120 /bin/bash -c ". /home/vmagent/app/e2eaiok/tests/cicd/jenkins_denas_cnn.sh"'
+                sh 'docker run --rm --name test-denas-cnn --privileged --network host --device=/dev/dri -v /mnt/DP_disk1/dataset:/home/vmagent/app/dataset -v `pwd`:/home/vmagent/app/e2eaiok -w /home/vmagent/app/ e2eaiok-pytorch112 /bin/bash -c ". /home/vmagent/app/e2eaiok/tests/cicd/jenkins_denas_cnn.sh"'
             }
         }
         stage('Run DeNas ViT') {
@@ -35,7 +35,7 @@ pipeline {
                 label 'sr612'
             }
             steps {
-                sh 'docker run --rm --name test-denas-vit --privileged --network host --device=/dev/dri -v /mnt/DP_disk1/dataset:/home/vmagent/app/dataset -v `pwd`:/home/vmagent/app/e2eaiok -w /home/vmagent/app/ e2eaiok-pytorch120 /bin/bash -c ". /home/vmagent/app/e2eaiok/tests/cicd/jenkins_denas_vit.sh"'
+                sh 'docker run --rm --name test-denas-vit --privileged --network host --device=/dev/dri -v /mnt/DP_disk1/dataset:/home/vmagent/app/dataset -v `pwd`:/home/vmagent/app/e2eaiok -w /home/vmagent/app/ e2eaiok-pytorch112 /bin/bash -c ". /home/vmagent/app/e2eaiok/tests/cicd/jenkins_denas_vit.sh"'
             }
         }
         stage('Run DeNas Bert') {
@@ -43,7 +43,7 @@ pipeline {
                 label 'sr612'
             }
             steps {
-               sh 'docker run --rm --name test-denas-bert --privileged --network host --device=/dev/dri -v /mnt/DP_disk1/dataset:/home/vmagent/app/dataset -v `pwd`:/home/vmagent/app/e2eaiok -w /home/vmagent/app/ e2eaiok-pytorch120 /bin/bash -c ". /home/vmagent/app/e2eaiok/tests/cicd/jenkins_denas_bert.sh"' 
+               sh 'docker run --rm --name test-denas-bert --privileged --network host --device=/dev/dri -v /mnt/DP_disk1/dataset:/home/vmagent/app/dataset -v `pwd`:/home/vmagent/app/e2eaiok -w /home/vmagent/app/ e2eaiok-pytorch112 /bin/bash -c ". /home/vmagent/app/e2eaiok/tests/cicd/jenkins_denas_bert.sh"' 
             }
         }
         stage('Run DeNas ASR') {
@@ -51,7 +51,7 @@ pipeline {
                 label 'sr612'
             }
             steps {
-               sh 'docker run --rm --name test-denas-asr --privileged --network host --device=/dev/dri -v /mnt/DP_disk1/dataset:/home/vmagent/app/dataset -v `pwd`:/home/vmagent/app/e2eaiok -w /home/vmagent/app/ e2eaiok-pytorch120 /bin/bash -c ". /home/vmagent/app/e2eaiok/tests/cicd/jenkins_denas_asr.sh"' 
+               sh 'docker run --rm --name test-denas-asr --privileged --network host --device=/dev/dri -v /mnt/DP_disk1/dataset:/home/vmagent/app/dataset -v `pwd`:/home/vmagent/app/e2eaiok -w /home/vmagent/app/ e2eaiok-pytorch112 /bin/bash -c ". /home/vmagent/app/e2eaiok/tests/cicd/jenkins_denas_asr.sh"' 
             }
         }
     }


### PR DESCRIPTION
Fix for the Dockerfile name typo:
**DockerfilePytorch120 --> DockerfilePytorch112** 
because pytorch==1.12 and make the format aligned with DockerfilePytorch110 (pytorch==1.10)