### PR TITLE
[v1.1] Refine DeNas module import

### DIFF
--- a/e2eAIOK/DeNas/asr/TransformerBase.py
+++ b/e2eAIOK/DeNas/asr/TransformerBase.py
@@ -3,9 +3,9 @@ import torch
 import torch.nn as nn
 from typing import Optional
 
-from module.asr.attention import RelPosEncXL, MultiheadAttention, RelPosMHAXL, PositionalwiseFeedForward
-from module.asr.normalization import LayerNorm
-from module.asr.embedding import Embedding
+from e2eAIOK.DeNas.module.asr.attention import RelPosEncXL, MultiheadAttention, RelPosMHAXL, PositionalwiseFeedForward
+from e2eAIOK.DeNas.module.asr.normalization import LayerNorm
+from e2eAIOK.DeNas.module.asr.embedding import Embedding
 
 
 class TransformerBase(nn.Module):

--- a/e2eAIOK/DeNas/asr/TransformerLM.py
+++ b/e2eAIOK/DeNas/asr/TransformerLM.py
@@ -1,10 +1,10 @@
 import torch
 from torch import nn
 
-from module.asr.linear import Linear
-from module.asr.normalization import LayerNorm
-from lib.containers import ModuleList
-from TransformerBase import (
+from e2eAIOK.DeNas.module.asr.linear import Linear
+from e2eAIOK.DeNas.module.asr.normalization import LayerNorm
+from e2eAIOK.DeNas.asr.lib.containers import ModuleList
+from e2eAIOK.DeNas.asr.TransformerBase import (
     TransformerBase,
     get_lookahead_mask,
     get_key_padding_mask,

--- a/e2eAIOK/DeNas/asr/asr_model_builder.py
+++ b/e2eAIOK/DeNas/asr/asr_model_builder.py
@@ -1,16 +1,15 @@
 import os
 import sys
-# sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
 import ast
 import torch
 import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.nn import SyncBatchNorm
 
-from asr.lib.convolution import ConvolutionFrontEnd
-from module.asr.linear import Linear
-from asr.data.processing.features import InputNormalization
-from module.asr.utils import gen_transformer
+from e2eAIOK.DeNas.asr.lib.convolution import ConvolutionFrontEnd
+from e2eAIOK.DeNas.module.asr.linear import Linear
+from e2eAIOK.DeNas.asr.data.processing.features import InputNormalization
+from e2eAIOK.DeNas.module.asr.utils import gen_transformer
 from trainer.ModelBuilder import BaseModelBuilder
 
 class ASRModelBuilder(BaseModelBuilder):

--- a/e2eAIOK/DeNas/asr/asr_trainer.py
+++ b/e2eAIOK/DeNas/asr/asr_trainer.py
@@ -1,8 +1,5 @@
 import os
 import sys
-current_dir = os.path.split(os.path.abspath(__file__))[0]
-cls_path = current_dir.rsplit("/", 3)[0]
-sys.path.append(cls_path)
 import sys
 import torch
 import logging
@@ -11,16 +8,16 @@ import yaml
 import sentencepiece as sp
 import torch.distributed as dist
 
-from asr.data.dataio.dataloader import get_dataloader, make_dataloader
-from asr.data.dataio.dataset import dataio_prepare
-from asr.utils.utils import check_gradients, update_average, create_experiment_directory, init_log
-from asr.utils.parameter_transfer import load_torch_model, load_spm
-from asr.trainer.losses import ctc_loss, kldiv_loss
-from asr.trainer.schedulers import NoamScheduler
-from asr.data.augment import SpecAugment
-from asr.data.features import Fbank
-from asr.utils.Accuracy import AccuracyStats
-from asr.utils.metric_stats import ErrorRateStats
+from e2eAIOK.DeNas.asr.data.dataio.dataloader import get_dataloader, make_dataloader
+from e2eAIOK.DeNas.asr.data.dataio.dataset import dataio_prepare
+from e2eAIOK.DeNas.asr.utils.utils import check_gradients, update_average, create_experiment_directory, init_log
+from e2eAIOK.DeNas.asr.utils.parameter_transfer import load_torch_model, load_spm
+from e2eAIOK.DeNas.asr.trainer.losses import ctc_loss, kldiv_loss
+from e2eAIOK.DeNas.asr.trainer.schedulers import NoamScheduler
+from e2eAIOK.DeNas.asr.data.augment import SpecAugment
+from e2eAIOK.DeNas.asr.data.features import Fbank
+from e2eAIOK.DeNas.asr.utils.Accuracy import AccuracyStats
+from e2eAIOK.DeNas.asr.utils.metric_stats import ErrorRateStats
 from e2eAIOK.common.trainer.torch_trainer import TorchTrainer
 import e2eAIOK.common.trainer.utils.extend_distributed as ext_dist
 

--- a/e2eAIOK/DeNas/asr/data/dataio/batch.py
+++ b/e2eAIOK/DeNas/asr/data/dataio/batch.py
@@ -5,9 +5,9 @@ from torch.utils.data._utils.pin_memory import (
     pin_memory as recursive_pin_memory,
 )
 
-from asr.utils.data_utils import mod_default_collate
-from asr.utils.data_utils import recursive_to
-from asr.utils.data_utils import batch_pad_right
+from e2eAIOK.DeNas.asr.utils.data_utils import mod_default_collate
+from e2eAIOK.DeNas.asr.utils.data_utils import recursive_to
+from e2eAIOK.DeNas.asr.utils.data_utils import batch_pad_right
 
 
 PaddedData = collections.namedtuple("PaddedData", ["data", "lengths"])

--- a/e2eAIOK/DeNas/asr/data/dataio/dataloader.py
+++ b/e2eAIOK/DeNas/asr/data/dataio/dataloader.py
@@ -5,10 +5,10 @@ import logging
 from torch.utils.data import DistributedSampler
 import torch.distributed as dist
 
-from asr.data.dataio.batch import PaddedBatch
-from asr.data.dataio.dataset import DynamicItemDataset
-from asr.data.dataio.sampler import ReproducibleRandomSampler, DistributedSamplerWrapper
-from asr.utils.checkpoints import (
+from e2eAIOK.DeNas.asr.data.dataio.batch import PaddedBatch
+from e2eAIOK.DeNas.asr.data.dataio.dataset import DynamicItemDataset
+from e2eAIOK.DeNas.asr.data.dataio.sampler import ReproducibleRandomSampler, DistributedSamplerWrapper
+from e2eAIOK.DeNas.asr.utils.checkpoints import (
     mark_as_saver,
     mark_as_loader,
 )

--- a/e2eAIOK/DeNas/asr/data/dataio/dataset.py
+++ b/e2eAIOK/DeNas/asr/data/dataio/dataset.py
@@ -6,10 +6,10 @@ from types import MethodType
 from torch.utils.data import Dataset
 import logging
 
-from asr.utils.data_pipeline import DataPipeline
-from asr.data.dataio.dataio import load_data_json, load_data_csv, read_audio
-from asr.data.processing.speech_augmentation import SpeedPerturb
-import asr.utils as utils
+from e2eAIOK.DeNas.asr.utils.data_pipeline import DataPipeline
+from e2eAIOK.DeNas.asr.data.dataio.dataio import load_data_json, load_data_csv, read_audio
+from e2eAIOK.DeNas.asr.data.processing.speech_augmentation import SpeedPerturb
+import e2eAIOK.DeNas.asr.utils as utils
 
 
 logger = logging.getLogger(__name__)

--- a/e2eAIOK/DeNas/asr/data/dataio/wer.py
+++ b/e2eAIOK/DeNas/asr/data/dataio/wer.py
@@ -1,6 +1,6 @@
 import sys
 
-from asr.utils import edit_distance
+from e2eAIOK.DeNas.asr.utils import edit_distance
 
 
 def print_wer_summary(wer_details, file=sys.stdout):

--- a/e2eAIOK/DeNas/asr/data/features.py
+++ b/e2eAIOK/DeNas/asr/data/features.py
@@ -1,5 +1,5 @@
 import torch
-from asr.data.processing.features import (
+from e2eAIOK.DeNas.asr.data.processing.features import (
     STFT,
     spectral_magnitude,
     Filterbank,

--- a/e2eAIOK/DeNas/asr/data/librispeech_prepare.py
+++ b/e2eAIOK/DeNas/asr/data/librispeech_prepare.py
@@ -5,11 +5,9 @@ from collections import Counter
 import logging
 import torchaudio
 import os, sys
-current_dir = os.path.split(os.path.abspath(__file__))[0]
-cls_path = current_dir.rsplit("/", 2)[0]
-sys.path.append(cls_path)
-from asr.utils.data_utils import download_file, get_all_files
-from asr.data.dataio.dataio import (
+
+from e2eAIOK.DeNas.asr.utils.data_utils import download_file, get_all_files
+from e2eAIOK.DeNas.asr.data.dataio.dataio import (
     load_pkl,
     save_pkl,
     merge_csvs,

--- a/e2eAIOK/DeNas/asr/lib/convolution.py
+++ b/e2eAIOK/DeNas/asr/lib/convolution.py
@@ -1,7 +1,7 @@
 import torch
-from asr.lib.CNN import Conv2d
-from asr.lib.containers import Sequential
-from module.asr.normalization import LayerNorm
+from e2eAIOK.DeNas.asr.lib.CNN import Conv2d
+from e2eAIOK.DeNas.asr.lib.containers import Sequential
+from e2eAIOK.DeNas.module.asr.normalization import LayerNorm
 
 
 class ConvolutionFrontEnd(Sequential):

--- a/e2eAIOK/DeNas/asr/supernet_asr.py
+++ b/e2eAIOK/DeNas/asr/supernet_asr.py
@@ -3,20 +3,17 @@ from torch import nn
 from typing import Optional
 
 import os, sys
-current_dir = os.path.split(os.path.abspath(__file__))[0]
-cls_path = current_dir.rsplit("/", 1)[0]
-sys.path.append(cls_path)
 
-from module.asr.linear import Linear
-from asr.TransformerBase import (
+from e2eAIOK.DeNas.module.asr.linear import Linear
+from e2eAIOK.DeNas.asr.TransformerBase import (
     get_lookahead_mask,
     get_key_padding_mask,
     NormalizedEmbedding,
     PositionalEncoding
 )
-from module.asr.encoder import TransformerEncoder
-from module.asr.decoder import TransformerDecoder
-from asr.data.dataio.dataio import length_to_mask
+from e2eAIOK.DeNas.module.asr.encoder import TransformerEncoder
+from e2eAIOK.DeNas.module.asr.decoder import TransformerDecoder
+from e2eAIOK.DeNas.asr.data.dataio.dataio import length_to_mask
 
 
 class TransformerASRSuper(nn.Module):

--- a/e2eAIOK/DeNas/asr/trainer/losses.py
+++ b/e2eAIOK/DeNas/asr/trainer/losses.py
@@ -1,7 +1,7 @@
 import torch
 import logging
 import functools
-from asr.data.dataio.dataio import length_to_mask
+from e2eAIOK.DeNas.asr.data.dataio.dataio import length_to_mask
 
 
 logger = logging.getLogger(__name__)

--- a/e2eAIOK/DeNas/asr/trainer/schedulers.py
+++ b/e2eAIOK/DeNas/asr/trainer/schedulers.py
@@ -1,7 +1,7 @@
 import torch
 import logging
 
-from asr.utils import checkpoints
+from e2eAIOK.DeNas.asr.utils import checkpoints
 
 logger = logging.getLogger(__name__)
 

--- a/e2eAIOK/DeNas/asr/utils/Accuracy.py
+++ b/e2eAIOK/DeNas/asr/utils/Accuracy.py
@@ -1,5 +1,5 @@
 import torch
-from asr.data.dataio.dataio import length_to_mask
+from e2eAIOK.DeNas.asr.data.dataio.dataio import length_to_mask
 
 
 def Accuracy(log_probabilities, targets, length=None):

--- a/e2eAIOK/DeNas/asr/utils/asr_nas.py
+++ b/e2eAIOK/DeNas/asr/utils/asr_nas.py
@@ -1,13 +1,9 @@
 import random
 
 import os, sys
-current_dir = os.path.split(os.path.abspath(__file__))[0]
-cls_path = current_dir.rsplit("/", 1)[0]
-print(f"paths: {current_dir}, {cls_path}")
-sys.path.append(cls_path)
-print(sys.path)
 
-from module.asr.utils import gen_transformer
+
+from e2eAIOK.DeNas.module.asr.utils import gen_transformer
 
 def asr_decode_cand_tuple(cand):
     depth = cand[0]

--- a/e2eAIOK/DeNas/asr/utils/data_pipeline.py
+++ b/e2eAIOK/DeNas/asr/utils/data_pipeline.py
@@ -1,6 +1,6 @@
 import inspect
 from dataclasses import dataclass
-from asr.utils.depgraph import DependencyGraph
+from e2eAIOK.DeNas.asr.utils.depgraph import DependencyGraph
 
 
 @dataclass

--- a/e2eAIOK/DeNas/asr/utils/data_utils.py
+++ b/e2eAIOK/DeNas/asr/utils/data_utils.py
@@ -7,7 +7,7 @@ import torch
 import tqdm
 import pathlib
 
-from asr.utils.utils import is_main_process, ddp_barrier
+from e2eAIOK.DeNas.asr.utils.utils import is_main_process, ddp_barrier
 
 
 def undo_padding(batch, lengths):

--- a/e2eAIOK/DeNas/asr/utils/metric_stats.py
+++ b/e2eAIOK/DeNas/asr/utils/metric_stats.py
@@ -1,9 +1,9 @@
 import torch
 from joblib import Parallel, delayed
-from asr.utils.data_utils import undo_padding
-from asr.utils.edit_distance import wer_summary, wer_details_for_batch
-from asr.data.dataio.dataio import merge_char, split_word
-from asr.data.dataio.wer import print_wer_summary, print_alignments
+from e2eAIOK.DeNas.asr.utils.data_utils import undo_padding
+from e2eAIOK.DeNas.asr.utils.edit_distance import wer_summary, wer_details_for_batch
+from e2eAIOK.DeNas.asr.data.dataio.dataio import merge_char, split_word
+from e2eAIOK.DeNas.asr.data.dataio.wer import print_wer_summary, print_alignments
 
 
 class MetricStats:

--- a/e2eAIOK/DeNas/cv/benchmark_network_latency.py
+++ b/e2eAIOK/DeNas/cv/benchmark_network_latency.py
@@ -6,7 +6,6 @@ import os
 import sys
 import time
 import torch
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 def get_model_latency(model, batch_size, resolution, in_channels, gpu, repeat_times, fp16):
     if gpu is not None:

--- a/e2eAIOK/DeNas/module/asr/attention.py
+++ b/e2eAIOK/DeNas/module/asr/attention.py
@@ -5,8 +5,8 @@ from typing import Optional
 import torch.nn.functional as F
 import math
 
-from module.asr.linear import Linear
-from module.attention_base import AttentionBase
+from e2eAIOK.DeNas.module.asr.linear import Linear
+from e2eAIOK.DeNas.module.attention_base import AttentionBase
 
 
 logger = logging.getLogger(__name__)

--- a/e2eAIOK/DeNas/module/asr/decoder.py
+++ b/e2eAIOK/DeNas/module/asr/decoder.py
@@ -3,8 +3,8 @@ import torch
 import torch.nn as nn
 from typing import Optional
 
-from module.asr.attention import MultiheadAttention, PositionalwiseFeedForward
-from module.asr.normalization import LayerNorm
+from e2eAIOK.DeNas.module.asr.attention import MultiheadAttention, PositionalwiseFeedForward
+from e2eAIOK.DeNas.module.asr.normalization import LayerNorm
 
 class TransformerDecoderLayer(nn.Module):
     def __init__(

--- a/e2eAIOK/DeNas/module/asr/embedding.py
+++ b/e2eAIOK/DeNas/module/asr/embedding.py
@@ -1,6 +1,6 @@
 import torch.nn.functional as F
 
-from module.embedding_base import EmbeddingBase
+from e2eAIOK.DeNas.module.embedding_base import EmbeddingBase
 
 
 class Embedding(EmbeddingBase):

--- a/e2eAIOK/DeNas/module/asr/encoder.py
+++ b/e2eAIOK/DeNas/module/asr/encoder.py
@@ -3,8 +3,8 @@ import torch
 import torch.nn as nn
 from typing import Optional
 
-from module.asr.attention import MultiheadAttention, PositionalwiseFeedForward
-from module.asr.normalization import LayerNorm
+from e2eAIOK.DeNas.module.asr.attention import MultiheadAttention, PositionalwiseFeedForward
+from e2eAIOK.DeNas.module.asr.normalization import LayerNorm
 
 class TransformerEncoderLayer(nn.Module):
     def __init__(

--- a/e2eAIOK/DeNas/module/asr/linear.py
+++ b/e2eAIOK/DeNas/module/asr/linear.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from module.Linear_base import LinearBase
+from e2eAIOK.DeNas.module.Linear_base import LinearBase
 
 
 class Linear(LinearBase):

--- a/e2eAIOK/DeNas/module/asr/normalization.py
+++ b/e2eAIOK/DeNas/module/asr/normalization.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn.functional as F
 
-from module.layernorm_base import LayerNormBase
+from e2eAIOK.DeNas.module.layernorm_base import LayerNormBase
 
 
 class LayerNorm(LayerNormBase):

--- a/e2eAIOK/DeNas/module/asr/utils.py
+++ b/e2eAIOK/DeNas/module/asr/utils.py
@@ -1,6 +1,6 @@
 import torch
 
-from asr.supernet_asr import TransformerASRSuper
+from e2eAIOK.DeNas.asr.supernet_asr import TransformerASRSuper
 
 
 def gen_transformer(

--- a/e2eAIOK/DeNas/module/cv/embedding_super.py
+++ b/e2eAIOK/DeNas/module/cv/embedding_super.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from .utils import to_2tuple
+from e2eAIOK.DeNas.module.cv.utils import to_2tuple
 import numpy as np
 
 

--- a/e2eAIOK/DeNas/module/cv/multihead_super.py
+++ b/e2eAIOK/DeNas/module/cv/multihead_super.py
@@ -4,9 +4,9 @@ from torch.nn import Parameter
 import torch.nn.functional as F
 
 from e2eAIOK.DeNas.module.attention_base import AttentionBase
-from .Linear_super import LinearSuper
-from .qkv_super import qkv_super
-from .utils import trunc_normal_
+from e2eAIOK.DeNas.module.cv.Linear_super import LinearSuper
+from e2eAIOK.DeNas.module.cv.qkv_super import qkv_super
+from e2eAIOK.DeNas.module.cv.utils import trunc_normal_
 
 
 def softmax(x, dim, onnx_trace=False):

--- a/e2eAIOK/DeNas/module/nlp/Linear_super.py
+++ b/e2eAIOK/DeNas/module/nlp/Linear_super.py
@@ -2,7 +2,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import numpy as np
 
-from module.Linear_base import LinearBase
+from e2eAIOK.DeNas.module.Linear_base import LinearBase
 
 
 class LinearSuper(LinearBase):

--- a/e2eAIOK/DeNas/module/nlp/bert_attention_super.py
+++ b/e2eAIOK/DeNas/module/nlp/bert_attention_super.py
@@ -24,8 +24,8 @@ import math
 import torch
 from torch import nn
 
-from module.nlp.Linear_super import LinearSuper as SuperLinear
-from module.nlp.layernorm_super import LayerNormSuper as SuperBertLayerNorm
+from e2eAIOK.DeNas.module.nlp.Linear_super import LinearSuper as SuperLinear
+from e2eAIOK.DeNas.module.nlp.layernorm_super import LayerNormSuper as SuperBertLayerNorm
 
 
 logging.basicConfig(format='%(asctime)s - %(levelname)s - %(name)s -   %(message)s',

--- a/e2eAIOK/DeNas/module/nlp/bert_embedding_super.py
+++ b/e2eAIOK/DeNas/module/nlp/bert_embedding_super.py
@@ -5,7 +5,7 @@ import torch
 from torch import nn
 import torch.nn.functional as F
 
-from module.nlp.layernorm_super import LayerNormSuper as SuperBertLayerNorm
+from e2eAIOK.DeNas.module.nlp.layernorm_super import LayerNormSuper as SuperBertLayerNorm
 
 
 logging.basicConfig(format='%(asctime)s - %(levelname)s - %(name)s -   %(message)s',

--- a/e2eAIOK/DeNas/module/nlp/bert_encoder_super.py
+++ b/e2eAIOK/DeNas/module/nlp/bert_encoder_super.py
@@ -6,10 +6,10 @@ import copy
 import torch
 from torch import nn
 
-from module.nlp.Linear_super import LinearSuper as SuperLinear
-from module.nlp.layernorm_super import LayerNormSuper as SuperBertLayerNorm
-from module.nlp.bert_attention_super import SuperBertAttention
-from module.nlp.bert_intermediate_super import SuperBertIntermediate
+from e2eAIOK.DeNas.module.nlp.Linear_super import LinearSuper as SuperLinear
+from e2eAIOK.DeNas.module.nlp.layernorm_super import LayerNormSuper as SuperBertLayerNorm
+from e2eAIOK.DeNas.module.nlp.bert_attention_super import SuperBertAttention
+from e2eAIOK.DeNas.module.nlp.bert_intermediate_super import SuperBertIntermediate
 
 
 logging.basicConfig(format='%(asctime)s - %(levelname)s - %(name)s -   %(message)s',

--- a/e2eAIOK/DeNas/module/nlp/bert_intermediate_super.py
+++ b/e2eAIOK/DeNas/module/nlp/bert_intermediate_super.py
@@ -7,7 +7,7 @@ import logging
 import torch
 from torch import nn
 
-from module.nlp.Linear_super import LinearSuper as SuperLinear
+from e2eAIOK.DeNas.module.nlp.Linear_super import LinearSuper as SuperLinear
 
 
 logging.basicConfig(format='%(asctime)s - %(levelname)s - %(name)s -   %(message)s',

--- a/e2eAIOK/DeNas/module/nlp/bert_pooler_super.py
+++ b/e2eAIOK/DeNas/module/nlp/bert_pooler_super.py
@@ -5,7 +5,7 @@ import logging
 import torch
 from torch import nn
 
-from module.nlp.Linear_super import LinearSuper as SuperLinear
+from e2eAIOK.DeNas.module.nlp.Linear_super import LinearSuper as SuperLinear
 
 
 logging.basicConfig(format='%(asctime)s - %(levelname)s - %(name)s -   %(message)s',

--- a/e2eAIOK/DeNas/module/nlp/layernorm_super.py
+++ b/e2eAIOK/DeNas/module/nlp/layernorm_super.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from module.layernorm_base import LayerNormBase
+from e2eAIOK.DeNas.module.layernorm_base import LayerNormBase
 
 
 class LayerNormSuper(LayerNormBase):

--- a/e2eAIOK/DeNas/nlp/supernet_bert.py
+++ b/e2eAIOK/DeNas/nlp/supernet_bert.py
@@ -13,11 +13,11 @@ import torch
 from torch import embedding, nn
 from torch.nn import CrossEntropyLoss
 
-from module.nlp.Linear_super import LinearSuper as SuperLinear
-from module.nlp.layernorm_super import LayerNormSuper as SuperBertLayerNorm
-from module.nlp.bert_embedding_super import SuperBertEmbeddings
-from module.nlp.bert_encoder_super import SuperBertEncoder
-from module.nlp.bert_pooler_super import SuperBertPooler
+from e2eAIOK.DeNas.module.nlp.Linear_super import LinearSuper as SuperLinear
+from e2eAIOK.DeNas.module.nlp.layernorm_super import LayerNormSuper as SuperBertLayerNorm
+from e2eAIOK.DeNas.module.nlp.bert_embedding_super import SuperBertEmbeddings
+from e2eAIOK.DeNas.module.nlp.bert_encoder_super import SuperBertEncoder
+from e2eAIOK.DeNas.module.nlp.bert_pooler_super import SuperBertPooler
 
 logging.basicConfig(format='%(asctime)s - %(levelname)s - %(name)s -   %(message)s',
                     datefmt='%m/%d/%Y %H:%M:%S',

--- a/e2eAIOK/DeNas/nlp/utils.py
+++ b/e2eAIOK/DeNas/nlp/utils.py
@@ -10,12 +10,12 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 import e2eAIOK.common.trainer.utils.extend_distributed as ext_dist
-from module.nlp.optimization import BertAdam
-from nlp.supernet_bert import CrossEntropyQALoss
-from nlp.utils_eval import do_qa_eval
+from e2eAIOK.DeNas.module.nlp.optimization import BertAdam
+from e2eAIOK.DeNas.nlp.supernet_bert import CrossEntropyQALoss
+from e2eAIOK.DeNas.nlp.utils_eval import do_qa_eval
 
-from module.nlp.layernorm_super import LayerNormSuper
-from module.nlp.Linear_super import LinearSuper
+from e2eAIOK.DeNas.module.nlp.layernorm_super import LayerNormSuper
+from e2eAIOK.DeNas.module.nlp.Linear_super import LinearSuper
 from thop.vision.basic_hooks import count_normalization, count_linear
 from ptflops.pytorch_ops import linear_flops_counter_hook
 

--- a/e2eAIOK/DeNas/nlp/utils_eval.py
+++ b/e2eAIOK/DeNas/nlp/utils_eval.py
@@ -10,7 +10,7 @@ import collections
 from datetime import datetime
 from collections import Counter
 
-from module.nlp.tokenization import BasicTokenizer
+from e2eAIOK.DeNas.module.nlp.tokenization import BasicTokenizer
 
 logging.basicConfig(format='%(asctime)s - %(levelname)s - %(name)s -   %(message)s', datefmt='%m/%d/%Y %H:%M:%S', level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/e2eAIOK/DeNas/scores/basic_utils.py
+++ b/e2eAIOK/DeNas/scores/basic_utils.py
@@ -1,6 +1,5 @@
 
 import os, sys, time
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import torch
 from torch import nn
 import numpy as np

--- a/e2eAIOK/DeNas/scores/compute_de_score.py
+++ b/e2eAIOK/DeNas/scores/compute_de_score.py
@@ -1,7 +1,6 @@
 
 
 import os, sys, time
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import torch
 from torch import nn
 import numpy as np
@@ -9,8 +8,8 @@ import gc
 
 import torch
 
-from scores.basic_utils import *
-from scores.transformer_proxy import do_compute_nas_score_transformer
+from e2eAIOK.DeNas.scores.basic_utils import network_weight_gaussian_init, get_ntk_n, compute_synflow_per_weight
+from e2eAIOK.DeNas.scores.transformer_proxy import do_compute_nas_score_transformer
 
 def do_compute_nas_score_cnn(model_type, model, resolution, batch_size, mixup_gamma, expressivity_weight=0, complexity_weight=0, diversity_weight=0, saliency_weight=0, latency_weight=0):
     disversity_score = 0

--- a/e2eAIOK/DeNas/scores/transformer_proxy.py
+++ b/e2eAIOK/DeNas/scores/transformer_proxy.py
@@ -1,22 +1,21 @@
 import os, sys, time, math
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import torch
 from torch import nn
 import numpy as np
 import gc
 import torch
 # TODO: separate domain specific ops
-from module.cv.Linear_super import LinearSuper
-from module.cv.layernorm_super import LayerNormSuper
-from module.cv.multihead_super import AttentionSuper
-from module.cv.embedding_super import PatchembedSuper
-from cv.supernet_transformer import TransformerEncoderLayer
-from cv.benchmark_network_latency import get_model_latency
-from nlp.supernet_bert import SuperBertEncoder
-from nlp.utils import get_bert_latency
-from module.asr.encoder import TransformerEncoder
-from module.asr.attention import MultiheadAttention
-from module.asr.linear import Linear
+from e2eAIOK.DeNas.module.cv.Linear_super import LinearSuper
+from e2eAIOK.DeNas.module.cv.layernorm_super import LayerNormSuper
+from e2eAIOK.DeNas.module.cv.multihead_super import AttentionSuper
+from e2eAIOK.DeNas.module.cv.embedding_super import PatchembedSuper
+from e2eAIOK.DeNas.cv.supernet_transformer import TransformerEncoderLayer
+from e2eAIOK.DeNas.cv.benchmark_network_latency import get_model_latency
+from e2eAIOK.DeNas.nlp.supernet_bert import SuperBertEncoder
+from e2eAIOK.DeNas.nlp.utils import get_bert_latency
+from e2eAIOK.DeNas.module.asr.encoder import TransformerEncoder
+from e2eAIOK.DeNas.module.asr.attention import MultiheadAttention
+from e2eAIOK.DeNas.module.asr.linear import Linear
 
 from torchsummary import summary
 


### PR DESCRIPTION
1. Refine DeNas module import: 
remove `sys.path.append()` in the module import part, and switch to `e2eAIOK.DeNas.*` to import module