### PR TITLE
[v1.1][ISSUE-206]Small fix or DE-NAS memory leakage issues

### DIFF
--- a/e2eAIOK/DeNas/scores/transformer_proxy.py
+++ b/e2eAIOK/DeNas/scores/transformer_proxy.py
@@ -222,7 +222,7 @@ def do_compute_nas_score_transformer(model_type, model, resolution, batch_size, 
     disversity_score = 0
     for grad_abs in disversity_score_list:
         if len(grad_abs.shape) == 0:
-            disversity_score += grad_abs
+            disversity_score += float(grad_abs)
         elif len(grad_abs.shape) == 2:
             disversity_score += float(torch.mean(torch.sum(grad_abs, dim=[1])))
 
@@ -261,4 +261,4 @@ def do_compute_nas_score_transformer(model_type, model, resolution, batch_size, 
                     + disversity_score*diversity_weight 
                     + saliency_score*saliency_weight)
     nas_score = score/(1 + latency*latency_weight)
-    return nas_score.item(), score.item(), latency
+    return nas_score, score, latency


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
Please open an issue for this pull request on Github Issues as well.
https://github.com/intel/e2eAIOK/issues
Pull Request Name format: [${VERSION_ID}][ISSUE-${ISSUES_ID}] ${detailed message}
ex: [v1.1][ISSUE-190] Add PR to issue link

  1. If the PR is unfinished and for comments purpose, add '[WIP]' in your PR title, e.g., '[VERSION_ID][ISSUE_ID][WIP]Your PR title ...'.
  2. Be sure to keep the PR description updated to reflect all changes.
  3. Please add PR title to describe what this PR proposes.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
-->
This PR fixed the memory leakage issues in the saliency score by converting the saliency score from a tensor to a float object.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new feature/API, clarify the use case for a new feature/API.
  2. If you fix a bug, mark which bug being fixed.
-->
In the "the transformer_proxy.py", nas_score was previously returned as a tensor and stored in the searched dict, which caused huge memory consumption by keeping such a large tensor in the search process. Going deeper into the DE-Score calculation, the DE-Score tensor was only caused by the saliency score calculation, while other scores (etc., saliency score) were float type.

Previous [PR#205 solution](https://github.com/intel/e2eAIOK/pull/205) will not cover all conditions (etc., only the saliency score needed as the DE-Score will return a float, and not cause the memory leakage issues).

### How was this patch tested?
<!--
please point to existing unittest or add new unittest to cover your changes. If this is a document change, please skip this request. 
-->
The existing DE-NAS HF integration test covers the current changes.
