### PR TITLE
[v1.1][ISSUE-213] Refine DE-NAS NLP Usage

### DIFF
--- a/conf/denas/nlp/e2eaiok_denas_bert.conf
+++ b/conf/denas/nlp/e2eaiok_denas_bert.conf
@@ -13,7 +13,7 @@ s_prob: 0.4
 crossover_num: 25
 mutation_num: 25
 pretrained_bert: /home/vmagent/app/dataset/bert-base-uncased
-pretrained_bert_config: /home/vmagent/app/dataset/bert-base-uncased/bert_config.json
+pretrained_bert_config: /home/vmagent/app/dataset/bert-base-uncased/config.json
 img_size: 128
 max_param_limits: 110
 min_param_limits: 55

--- a/demo/denas/bert/DENAS_BERT_DEMO.ipynb
+++ b/demo/denas/bert/DENAS_BERT_DEMO.ipynb
@@ -129,7 +129,7 @@
     "batch_size: 32\n",
     "supernet_cfg: ../../conf/denas/nlp/supernet-bert-base.yaml\n",
     "pretrained_bert: /home/vmagent/app/dataset/bert-base-uncased\n",
-    "pretrained_bert_config: /home/vmagent/app/dataset/bert-base-uncased/bert_config.json\n",
+    "pretrained_bert_config: /home/vmagent/app/dataset/bert-base-uncased/config.json\n",
     "\n",
     "# conf for evolutionary search engine\n",
     "random_max_epochs: 1000 #random search max epochs\n",

--- a/e2eAIOK/DeNas/nlp/bert_trainer.py
+++ b/e2eAIOK/DeNas/nlp/bert_trainer.py
@@ -44,7 +44,8 @@ class BERTTrainer(TorchTrainer):
                 from e2eAIOK.ModelAdapter.engine_core import transferrable_model
                 from e2eAIOK.ModelAdapter.engine_core.distiller import kd
             except Exception:
-                self.logger.info("Please pre-check and install the e2eAIOK-ModelAdaptor to use the transfer learning features")
+                self.logger.info("Since you're using distiller feature, please use below cmdline to install e2eAIOK-ModelAdaptor\n \
+                                 pip install e2eAIOK-ModelAdaptor")
                 raise ModuleNotFoundError
             try:
                 self.teacher_model = ModelBuilderNLPDeNas(self.cfg)._init_extra_model(self.cfg.teacher_model, self.cfg.teacher_model_structure)
@@ -139,3 +140,4 @@ class BERTTrainer(TorchTrainer):
             if self.is_stop:
                 break
         self._post_process()
+        

--- a/e2eAIOK/DeNas/nlp/bert_trainer.py
+++ b/e2eAIOK/DeNas/nlp/bert_trainer.py
@@ -39,14 +39,9 @@ class BERTTrainer(TorchTrainer):
         
         #whether to use the KD from MA
         if 'teacher_model' in self.cfg and self.cfg.teacher_model != 'None':
-            try:
-                from e2eAIOK.DeNas.nlp.model_builder_denas_nlp import ModelBuilderNLPDeNas
-                from e2eAIOK.ModelAdapter.engine_core import transferrable_model
-                from e2eAIOK.ModelAdapter.engine_core.distiller import kd
-            except Exception:
-                self.logger.info("Since you're using distiller feature, please use below cmdline to install e2eAIOK-ModelAdaptor\n \
-                                 pip install e2eAIOK-ModelAdaptor")
-                raise ModuleNotFoundError
+            from e2eAIOK.DeNas.nlp.model_builder_denas_nlp import ModelBuilderNLPDeNas
+            from e2eAIOK.ModelAdapter.engine_core import transferrable_model
+            from e2eAIOK.ModelAdapter.engine_core.distiller import kd
             try:
                 self.teacher_model = ModelBuilderNLPDeNas(self.cfg)._init_extra_model(self.cfg.teacher_model, self.cfg.teacher_model_structure)
             except Exception:

--- a/e2eAIOK/DeNas/nlp/bert_trainer.py
+++ b/e2eAIOK/DeNas/nlp/bert_trainer.py
@@ -39,9 +39,13 @@ class BERTTrainer(TorchTrainer):
         
         #whether to use the KD from MA
         if 'teacher_model' in self.cfg and self.cfg.teacher_model != 'None':
-            from e2eAIOK.DeNas.nlp.model_builder_denas_nlp import ModelBuilderNLPDeNas
-            from e2eAIOK.ModelAdapter.engine_core import transferrable_model
-            from e2eAIOK.ModelAdapter.engine_core.distiller import kd
+            try:
+                from e2eAIOK.DeNas.nlp.model_builder_denas_nlp import ModelBuilderNLPDeNas
+                from e2eAIOK.ModelAdapter.engine_core import transferrable_model
+                from e2eAIOK.ModelAdapter.engine_core.distiller import kd
+            except Exception:
+                self.logger.info("Please pre-check and install the e2eAIOK-ModelAdaptor to use the transfer learning features")
+                raise ModuleNotFoundError
             try:
                 self.teacher_model = ModelBuilderNLPDeNas(self.cfg)._init_extra_model(self.cfg.teacher_model, self.cfg.teacher_model_structure)
             except Exception:

--- a/e2eAIOK/DeNas/nlp/supernet_bert.py
+++ b/e2eAIOK/DeNas/nlp/supernet_bert.py
@@ -33,8 +33,8 @@ PRETRAINED_MODEL_ARCHIVE_MAP = {
     'bert-base-multilingual-cased': "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-multilingual-cased.tar.gz",
     'bert-base-chinese': "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-chinese.tar.gz",
 }
-BERT_CONFIG_NAME = 'bert_config.json'
-CONFIG_NAME = "bert_config.json"
+BERT_CONFIG_NAME = 'config.json'
+CONFIG_NAME = "config.json"
 WEIGHTS_NAME = "pytorch_model.bin"
 
 

--- a/e2eAIOK/common/trainer/data/nlp/data_builder_squad.py
+++ b/e2eAIOK/common/trainer/data/nlp/data_builder_squad.py
@@ -26,8 +26,13 @@ class DataBuilderSQuAD(DataBuilderNLP):
         dataset_train, train_examples, train_dataset, labels = build_dataset(is_train=True, args=self.cfg)
         dataset_val, val_examples, val_dataset, val_features, tokenizer = build_dataset(is_train=False, args=self.cfg)
         if 'teacher_model' in self.cfg and self.cfg.teacher_model != 'None':
-            from e2eAIOK.ModelAdapter.engine_core.distiller.utils import logits_wrap_dataset
-            dataset_train = logits_wrap_dataset(dataset_train, self.cfg.logits_dir, num_classes=self.cfg.num_classes, save_logits=self.cfg.is_saving_logits)
+            try:
+                from e2eAIOK.ModelAdapter.engine_core.distiller.utils import logits_wrap_dataset
+                dataset_train = logits_wrap_dataset(dataset_train, self.cfg.logits_dir, num_classes=self.cfg.num_classes, save_logits=self.cfg.is_saving_logits)
+            except Exception:
+                self.logger.info("Since you're using distiller feature, please use below cmdline to install e2eAIOK-ModelAdaptor\n \
+                    pip install e2eAIOK-ModelAdaptor")
+                raise ModuleNotFoundError
         self.dataset_train = dataset_train
         self.dataset_val = dataset_val
         return (train_examples, val_examples, val_dataset, val_features, tokenizer)

--- a/e2eAIOK/common/trainer/data/nlp/data_builder_squad.py
+++ b/e2eAIOK/common/trainer/data/nlp/data_builder_squad.py
@@ -11,8 +11,6 @@ from e2eAIOK.DeNas.module.nlp.tokenization import BertTokenizer, whitespace_toke
 from e2eAIOK.common.trainer.data.data_builder_nlp import DataBuilderNLP, DataProcessor, InputExample
 import e2eAIOK.common.trainer.utils.extend_distributed as ext_dist
 
-from e2eAIOK.ModelAdapter.engine_core.distiller.utils import logits_wrap_dataset
-
 logging.basicConfig(format='%(asctime)s - %(levelname)s - %(name)s -   %(message)s',
                     datefmt='%m/%d/%Y %H:%M:%S',
                     level=logging.INFO)
@@ -28,6 +26,7 @@ class DataBuilderSQuAD(DataBuilderNLP):
         dataset_train, train_examples, train_dataset, labels = build_dataset(is_train=True, args=self.cfg)
         dataset_val, val_examples, val_dataset, val_features, tokenizer = build_dataset(is_train=False, args=self.cfg)
         if 'teacher_model' in self.cfg and self.cfg.teacher_model != 'None':
+            from e2eAIOK.ModelAdapter.engine_core.distiller.utils import logits_wrap_dataset
             dataset_train = logits_wrap_dataset(dataset_train, self.cfg.logits_dir, num_classes=self.cfg.num_classes, save_logits=self.cfg.is_saving_logits)
         self.dataset_train = dataset_train
         self.dataset_val = dataset_val


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
Please open an issue for this pull request on Github Issues as well.
https://github.com/intel/e2eAIOK/issues
Pull Request Name format: [${VERSION_ID}][ISSUE-${ISSUES_ID}] ${detailed message}
ex: [v1.1][ISSUE-190] Add PR to issue link

  1. If the PR is unfinished and for comments purpose, add '[WIP]' in your PR title, e.g., '[VERSION_ID][ISSUE_ID][WIP]Your PR title ...'.
  2. Be sure to keep the PR description updated to reflect all changes.
  3. Please add PR title to describe what this PR proposes.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
-->
This PR contains the following two updated usage:

- Separate the MA module dependency of NLP workflow from DE-NAS NLP BERT training process
- Align the BERT configuration name to HF provided configuration name.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new feature/API, clarify the use case for a new feature/API.
  2. If you fix a bug, mark which bug being fixed.
-->

- The first update is used for DE-NAS separate usage in the DE-NAS NLP training, no need to depend on the MA modules.
- The second update is tended for making it easy usage for users: no need to change the downloaded model config name "config.json" from HF to "bert_config.json".

### How was this patch tested?
<!--
please point to existing unittest or add new unittest to cover your changes. If this is a document change, please skip this request. 
-->
Current changes are covered by DE-NAS NLP CI/CD test.
