### PR TITLE
[v1.1] [ISSUE-215] Fix ModelAdapter installation from pip 

### DIFF
--- a/e2eAIOK/ModelAdapter/requirements.txt
+++ b/e2eAIOK/ModelAdapter/requirements.txt
@@ -10,4 +10,3 @@ nnunet
 transformers
 thop
 intel_extension_for_pytorch==1.12.100 -f https://developer.intel.com/ipex-whl-stable    
-tllib==0.4 -i https://test.pypi.org/simple/ 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from setuptools import setup, find_packages
+from setuptools.command.install import install
 try:
     # pip >=20
     from pip._internal.network.session import PipSession
@@ -43,9 +44,18 @@ def setup_package(args):
         package_data = args["package_data"],
         python_requires=">=3.6",
         zip_safe=False,
+        cmdclass=args.get("cmdclass", {}),
         install_requires=args["install_requires"]
     )
     setup(**metadata)
+
+class post_install_ma(install):
+    def run(self):
+        install.run(self)
+        import os
+        print(f"pip install tllib==0.4")
+        os.system(f"pip install git+https://github.com/thuml/Transfer-Learning-Library.git")
+        
 
 if __name__ == '__main__':
     args = dict(
@@ -86,6 +96,7 @@ if __name__ == '__main__':
                                                 "e2eAIOK.SDA", "e2eAIOK.SDA.*", "e2eAIOK.dataloader", "e2eAIOK.utils",\
                                                 "e2eAIOK.DeNas", "e2eAIOK.DeNas.*"])
         args["package_data"] = {'e2eAIOK': ['version','common/default.conf','ModelAdapter/default_ma.conf']}
+        args['cmdclass'] = {'install': post_install_ma}
         install_reqs = parse_requirements("e2eAIOK/ModelAdapter/requirements.txt", session=False)
         # handle pip version compatibility
         try:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
Please open an issue for this pull request on Github Issues as well.
https://github.com/intel/e2eAIOK/issues
Pull Request Name format: [${VERSION_ID}][ISSUE-${ISSUES_ID}] ${detailed message}
ex: [v1.1][ISSUE-190] Add PR to issue link

  1. If the PR is unfinished and for comments purpose, add '[WIP]' in your PR title, e.g., '[VERSION_ID][ISSUE_ID][WIP]Your PR title ...'.
  2. Be sure to keep the PR description updated to reflect all changes.
  3. Please add PR title to describe what this PR proposes.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
-->

- Fix bug of unable to install ModelAdapter from pip, that is `pip install e2eAIOK-ModelAdapter --pre`.
- The bug was caused by `tllib`, which is in `test pypi` source, it is installed by `pip install -i https://test.pypi.org/simple/ tllib==0.4`, but pip search package from formal `pypi` source, so it cannot find `tllib`, and it abort installation
- To fix it, we add a post installation step in setup.py.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new feature/API, clarify the use case for a new feature/API.
  2. If you fix a bug, mark which bug being fixed.
-->
Users may not install ModelAdapter from pip.


### How was this patch tested?
<!--
please point to existing unittest or add new unittest to cover your changes. If this is a document change, please skip this request. 
-->
- step 1 package: `python3 setup.py bdist_wheel --ma`
- step 2 install test: `pip install dist/e2eAIOK_ModelAdapter*.whl`
- step 3 check package installation: `pip show tllib`
- step 4 run existing CI/CD workflow.
