### PR TITLE
[v1.1][ISSUE-270]fix JAVA_HOME issue when user specify JAVA_HOME already

### DIFF
--- a/RecDP/pyrecdp/__init__.py
+++ b/RecDP/pyrecdp/__init__.py
@@ -5,7 +5,10 @@ try:
 except:
     raise NotImplementedError("pyrecdp required pyspark pre-installed. Please do pip install pyspark==3.3.1")
 
-os.environ["JAVA_HOME"]="/usr/lib/jvm/java-8-openjdk-amd64/"
+if 'JAVA_HOME' not in os.environ:
+    os.environ["JAVA_HOME"]="/usr/lib/jvm/java-8-openjdk-amd64/"
+else:
+    print(f"JAVE_HOME is {os.environ['JAVA_HOME']}")
 os.environ["PYSPARK_PYTHON"]=sys.executable
 os.environ["PYSPARK_DRIVER_PYTHON"]=sys.executable
 os.environ["PYSPARK_WORKER_PYTHON"]=sys.executable

--- a/RecDP/setup.py
+++ b/RecDP/setup.py
@@ -34,9 +34,8 @@ class post_install(install):
 
 setuptools.setup(
     name="pyrecdp",
-    version="0.1.4",
+    version="0.1.5",
     author="INTEL AIA BDF",
-    author_email="chendi.xue@intel.com",
     description=
     "A data processing bundle for spark based recommender system operations",
     long_description=long_description,


### PR DESCRIPTION
### What changes were proposed in this pull request?
pyrecdp init py java_home setting will only set when no specify

### Why are the changes needed?
Fanli reported an error that recdp release override her prespecified JAVA_HOME, fix in this error



### How was this patch tested?
tested locally
