### PR TITLE
[v1.2][ISSUE-306]fix class name typo error

### DIFF
--- a/.github/workflows/unittest_llmutils_pipeline.yml
+++ b/.github/workflows/unittest_llmutils_pipeline.yml
@@ -4,8 +4,8 @@ on:
     branches:
     - main
     paths:
-    - 'RecDP/pyrecdp/LLM'
-    - 'RecDP/pyrecdp/primitives/operations'
+    - 'RecDP/pyrecdp/LLM/**'
+    - 'RecDP/pyrecdp/primitives/operations/**'
     - 'RecDP/tests/cicd/bashrun_unittest_llmutilspipeline.sh'
     - 'RecDP/tests/test_llmutils_operations.py'
 

--- a/RecDP/pyrecdp/LLM/TextPipeline.py
+++ b/RecDP/pyrecdp/LLM/TextPipeline.py
@@ -188,7 +188,7 @@ class ResumableTextPipeline(TextPipeline):
             if op.op in ['SourcedParquetReader', 'ParquetReader']:
                 op.op = 'PerfileSourcedParquetReader'
             if op.op in ['SourcedJsonlReader', 'JsonlReader']:
-                op.op = 'PerfileSourcedJsonlWriter'
+                op.op = 'PerfileSourcedJsonlReader'
             if op.op in ['ParquetWriter', 'PerfileParquetWriter']:
                 op.op = 'PerfileParquetWriter'
                 output_dir = op.config['output_dir']
@@ -207,6 +207,7 @@ class ResumableTextPipeline(TextPipeline):
             status_tracker = open(status_log_path, 'w')
             done_files = []
         self.export(os.path.join(output_dir, "pipeline.json"))
+        self.plot()
         
         # prepare pipeline
         if not hasattr(self, 'executable_pipeline') or not hasattr(self, 'executable_sequence'):

--- a/RecDP/pyrecdp/primitives/operations/__init__.py
+++ b/RecDP/pyrecdp/primitives/operations/__init__.py
@@ -2,7 +2,7 @@ from .base import Operation, BaseOperation
 from .data import DataFrameOperation
 from .dataframe import RDDToDataFrameConverter, SparkDataFrameToDataFrameConverter
 from .encode import TargetEncodeOperation
-from .text_reader import DatasetReader, JsonlReader, ParquetReader, SourcedJsonlReader, SourcedParquetReader
+from .text_reader import DatasetReader, JsonlReader, ParquetReader, SourcedJsonlReader, SourcedParquetReader, PerfileSourcedJsonlReader, PerfileSourcedParquetReader
 from .text_writer import PerfileParquetWriter, ParquetWriter, JsonlWriter, ClassifyJsonlWriter, ClassifyParquetWriter
 from .text_normalize import TextNormalize
 from .text_bytesize import TextBytesize

--- a/RecDP/pyrecdp/primitives/operations/text_reader.py
+++ b/RecDP/pyrecdp/primitives/operations/text_reader.py
@@ -157,7 +157,7 @@ LLMOPERATORS.register(SourcedParquetReader)
 class PerfileReader:
     pass
 
-class PerfileSourcedJsonlWriter(SourcedReader, PerfileReader):
+class PerfileSourcedJsonlReader(SourcedReader, PerfileReader):
     def __init__(self, input_dir = "", source_prefix = ""):
         super().__init__(input_dir = input_dir, source_prefix = source_prefix)
         self.support_spark = False
@@ -182,7 +182,7 @@ class PerfileSourcedJsonlWriter(SourcedReader, PerfileReader):
             ds = rd.read_text(file_path).map(lambda x: convert_json(x, source_id))
             self.cache.append((ds, source_id))
         return self.cache
-LLMOPERATORS.register(PerfileSourcedJsonlWriter)
+LLMOPERATORS.register(PerfileSourcedJsonlReader)
     
 class PerfileSourcedParquetReader(SourcedReader, PerfileReader):
     def __init__(self, input_dir = "", source_prefix = ""):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Errorly put PerfileSourcedJsonlReader as PerfileSoucedJsonlWriter, fix it here

### Why are the changes needed?
name type fix

### How was this patch tested?
UT
